### PR TITLE
added wildcard option, changed language in sample prompts to en-US

### DIFF
--- a/modelcontextprotocol/README.md
+++ b/modelcontextprotocol/README.md
@@ -113,6 +113,8 @@ mcp call list_products --params '{"limit": 2}' npx ts-node /<absolute-path>/ct-a
 
 ## Testing Using Claude Desktop
 
+NOTE: This will not work with Claude Desktop unless you uninstall node v16 from your machine!
+
 ```bash
 #  navigate to ../typescript
 pnpm run build

--- a/typescript/src/shared/product-search/prompts.ts
+++ b/typescript/src/shared/product-search/prompts.ts
@@ -18,9 +18,10 @@ The tool takes these arguments:
 - facets (array, optional): Facets to calculate counts, distinct values, or ranges on the result set.
 
 Example query formats:
+- Wildcard: { "wildcard": { "field": "name", "language": "en-US", "value": "*pasta*", "caseInsensitive": true } }
 - Exact match: { "exact": { "field": "variants.attributes.color", "fieldType": "text", "value": "red" } }
 - Range: { "range": { "field": "variants.price.centAmount", "fieldType": "number", "lte": 5000 } }
-- Full text: { "fullText": { "value": "running shoes", "locale": "en" } }
+- Full text: { "fullText": { "field": "name", "value": "running shoes", "language": "en-US" } }
 
 The API supports only those Locales configured in the Project.
 `;


### PR DESCRIPTION
Claude desktop was struggling with finding products, so I modified prompts.ts adding a "wildcard" option (and added case insensitive flag).  Changed default language to en-US to work within our demo environment(s).